### PR TITLE
Drop python 2 tand add python 3.8 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
 addons:
   apt:
     packages:


### PR DESCRIPTION
python 2 is not further developed and numpy also dropped support