### PR TITLE
Make PRNG usage seedable

### DIFF
--- a/bayesian_bootstrap/bootstrap.py
+++ b/bayesian_bootstrap/bootstrap.py
@@ -1,62 +1,69 @@
 import numpy as np
 from copy import deepcopy
 
-def mean(X, n_replications):
+
+def mean(X, n_replications, seed=None):
     """Simulate the posterior distribution of the mean.
 
     Parameter X: The observed data (array like)
 
     Parameter n_replications: The number of bootstrap replications to perform (positive integer)
 
+    Parameter seed: Seed for PRNG (default None)
+
     Returns: Samples from the posterior
     """
-    rg = np.random.default_rng()
-    weights = rg.dirichlet(np.ones(len(X)), n_replications)
+    weights = np.random.default_rng(seed).dirichlet(np.ones(len(X)), n_replications)
     return np.dot(X, weights.T)
 
-def var(X, n_replications):
+
+def var(X, n_replications, seed=None):
     """Simulate the posterior distribution of the variance.
 
     Parameter X: The observed data (array like)
 
     Parameter n_replications: The number of bootstrap replications to perform (positive integer)
 
+    Parameter seed: Seed for PRNG (default None)
+
     Returns: Samples from the posterior
     """
     samples = []
-    weights = np.random.dirichlet([1]*len(X), n_replications)
+    weights = np.random.default_rng(seed).dirichlet([1] * len(X), n_replications)
     for w in weights:
         samples.append(np.dot([x ** 2 for x in X], w) - np.dot(X, w) ** 2)
     return samples
 
-def covar(X, Y, n_replications):
+
+def covar(X, Y, n_replications, seed=None):
     """Simulate the posterior distribution of the covariance.
 
-        Parameter X: The observed data, first variable (array like)
+    Parameter X: The observed data, first variable (array like)
 
-        Parameter Y: The observed data, second (array like)
+    Parameter Y: The observed data, second (array like)
 
-        Parameter n_replications: The number of bootstrap replications to perform (positive integer)
+    Parameter n_replications: The number of bootstrap replications to perform (positive integer)
 
-        Returns: Samples from the posterior
+    Parameter seed: Seed for PRNG (default None)
+
+    Returns: Samples from the posterior
     """
     samples = []
-    weights = np.random.dirichlet([1]*len(X), n_replications)
+    weights = np.random.default_rng(seed).dirichlet([1] * len(X), n_replications)
     for w in weights:
         cv = _weighted_covariance(X, Y, w)
         samples.append(cv)
     return samples
 
 
-def pearsonr(X, Y, n_replications):
+def pearsonr(X, Y, n_replications, seed=None):
     """
     Pearson correlation coefficient and p-value for testing non-correlation.
 
     https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.pearsonr.html
 
     """
-    rg = np.random.default_rng()
-    weights = rg.dirichlet(np.ones(len(X)), n_replications)
+    weights = np.random.default_rng(seed).dirichlet(np.ones(len(X)), n_replications)
     return _weighted_pearsonr(X, Y, weights)
 
 
@@ -74,30 +81,28 @@ def _weighted_pearsonr(X, Y, w):
     Weighted Pearson correlation.
 
     """
-    return (
-        _weighted_covariance(X, Y, w)
-        / np.sqrt(
-            _weighted_covariance(X, X, w)
-            * _weighted_covariance(Y, Y, w)
-        )
-    )
+    return _weighted_covariance(X, Y, w) / np.sqrt(_weighted_covariance(X, X, w) * _weighted_covariance(Y, Y, w))
 
 
 def _weighted_ls(X, w, y):
     x_rows, x_cols = X.shape
     w_matrix = np.array(w) * np.eye(x_rows)
-    coef = np.dot(np.dot(np.dot(np.linalg.inv(np.dot(np.dot(X.T, w_matrix), X)), X.T), w_matrix), y)
+    coef = np.dot(
+        np.dot(np.dot(np.linalg.inv(np.dot(np.dot(X.T, w_matrix), X)), X.T), w_matrix),
+        y,
+    )
     return coef
 
-def linear_regression(X, y, n_replications):
+
+def linear_regression(X, y, n_replications, seed=None):
     coef_samples = []
-    intercept_samples = []
-    weights = np.random.dirichlet([1]*len(X), n_replications)
+    weights = np.random.default_rng(seed).dirichlet([1] * len(X), n_replications)
     for w in weights:
         coef_samples.append(_weighted_ls(X, w, y))
     return np.vstack(coef_samples)
 
-def bayesian_bootstrap(X, statistic, n_replications, resample_size,low_mem=False):
+
+def bayesian_bootstrap(X, statistic, n_replications, resample_size, low_mem=False, seed=None):
     """Simulate the posterior distribution of the given statistic.
 
     Parameter X: The observed data (array like)
@@ -107,27 +112,31 @@ def bayesian_bootstrap(X, statistic, n_replications, resample_size,low_mem=False
     Parameter n_replications: The number of bootstrap replications to perform (positive integer)
 
     Parameter resample_size: The size of the dataset in each replication
-    
+
     Parameter low_mem(bool): Generate the weights for each iteration lazily instead of in a single batch. Will use
     less memory, but will run slower as a result.
+
+    Parameter seed: Seed for PRNG (default None)
 
     Returns: Samples from the posterior
     """
     if isinstance(X, list):
         X = np.array(X)
     samples = []
+    rng = np.random.default_rng(seed)
     if low_mem:
-        weights = (np.random.dirichlet([1] * len(X)) for _ in range(n_replications))
+        weights = (rng.dirichlet([1] * len(X)) for _ in range(n_replications))
     else:
-        weights = np.random.dirichlet([1] * len(X), n_replications)
+        weights = rng.dirichlet([1] * len(X), n_replications)
     for w in weights:
-        sample_index = np.random.choice(range(len(X)), p=w, size=resample_size)
+        sample_index = rng.choice(range(len(X)), p=w, size=resample_size)
         resample_X = X[sample_index]
         s = statistic(resample_X)
         samples.append(s)
     return samples
 
-def bayesian_bootstrap_regression(X, y, statistic, n_replications, resample_size,low_mem=False):
+
+def bayesian_bootstrap_regression(X, y, statistic, n_replications, resample_size, low_mem=False, seed=None):
     """Simulate the posterior distribution of a statistic that uses dependent and independent variables.
 
     Parameter X: The observed data, independent variables (matrix like)
@@ -139,23 +148,26 @@ def bayesian_bootstrap_regression(X, y, statistic, n_replications, resample_size
     Parameter n_replications: The number of bootstrap replications to perform (positive integer)
 
     Parameter resample_size: The size of the dataset in each replication
-    
+
     Parameter low_mem(bool): Use looping instead of generating all the dirichlet, use if program use too much memory
+
+    Parameter seed: Seed for PRNG (default None)
 
     Returns: Samples from the posterior
     """
     samples = []
     X_arr = np.array(X)
     y_arr = np.array(y)
+    rng = np.random.default_rng(seed)
     if low_mem:
-        weights = (np.random.dirichlet([1] * len(X)) for _ in range(n_replications))
+        weights = (rng.dirichlet([1] * len(X)) for _ in range(n_replications))
     else:
-        weights = np.random.dirichlet([1] * len(X), n_replications)
+        weights = rng.dirichlet([1] * len(X), n_replications)
     for w in weights:
         if resample_size is None:
             s = statistic(X, y, w)
         else:
-            resample_i = np.random.choice(range(len(X_arr)), p=w, size=resample_size)
+            resample_i = rng.choice(range(len(X_arr)), p=w, size=resample_size)
             resample_X = X_arr[resample_i]
             resample_y = y_arr[resample_i]
             s = statistic(resample_X, resample_y)
@@ -164,9 +176,10 @@ def bayesian_bootstrap_regression(X, y, statistic, n_replications, resample_size
     return samples
 
 
-class BayesianBootstrapBagging(object):
+class BayesianBootstrapBagging:
     """A bootstrap aggregating model using the bayesian bootstrap. Similar to scikit-learn's BaggingRegressor."""
-    def __init__(self, base_learner, n_replications, resample_size=None, low_mem=False):
+
+    def __init__(self, base_learner, n_replications, resample_size=None, low_mem=False, seed=None):
         """Initialize the base learners of the ensemble.
 
         Parameter base_learner: A scikit-learn like estimator. This object should implement a fit() and predict()
@@ -175,14 +188,17 @@ class BayesianBootstrapBagging(object):
         Parameter n_replications: The number of bootstrap replications to perform (positive integer)
 
         Parameter resample_size: The size of the dataset in each replication
-        
+
         Parameter low_mem(bool): Generate the weights for each iteration lazily instead of in a single batch. Will use
         less memory, but will run slower as a result.
+
+        Parameter seed: Seed for PRNG (default None)
         """
         self.base_learner = base_learner
         self.n_replications = n_replications
         self.resample_size = resample_size
         self.memo = low_mem
+        self.seed = seed
 
     def fit(self, X, y):
         """Fit the base learners of the ensemble on a dataset.
@@ -194,16 +210,11 @@ class BayesianBootstrapBagging(object):
         Returns: Fitted model
         """
         if self.resample_size is None:
-            statistic = lambda X, y, w: deepcopy(self.base_learner).fit(X, y, w)
+            statistic = lambda X, y, w: deepcopy(self.base_learner).fit(X, y, w)  # noqa: E731
         else:
-            statistic = lambda X, y: deepcopy(self.base_learner).fit(X, y)
+            statistic = lambda X, y: deepcopy(self.base_learner).fit(X, y)  # noqa: E731
         self.base_models_ = bayesian_bootstrap_regression(
-            X,
-            y,
-            statistic,
-            self.n_replications,
-            self.resample_size,
-            low_mem=self.memo
+            X, y, statistic, self.n_replications, self.resample_size, low_mem=self.memo, seed=self.seed
         )
         return self
 
@@ -227,7 +238,7 @@ class BayesianBootstrapBagging(object):
         # Return a X_r x self.n_replications matrix
         y_posterior_samples = np.zeros((len(X), self.n_replications))
         for i, m in enumerate(self.base_models_):
-            y_posterior_samples[:,i] = m.predict(X)
+            y_posterior_samples[:, i] = m.predict(X)
         return y_posterior_samples
 
     def predict_central_interval(self, X, alpha=0.05):
@@ -254,6 +265,7 @@ class BayesianBootstrapBagging(object):
         y_posterior_samples = self.predict_posterior_samples(X)
         return np.array([highest_density_interval(r, alpha=alpha) for r in y_posterior_samples])
 
+
 def central_credible_interval(samples, alpha=0.05):
     """The equal-tailed interval containing a (1-alpha) fraction of the posterior samples.
 
@@ -263,9 +275,10 @@ def central_credible_interval(samples, alpha=0.05):
 
     Returns: Left and right interval bounds (tuple)
     """
-    tail_size = int(round(len(samples)*(alpha/2)))
+    tail_size = int(round(len(samples) * (alpha / 2)))
     samples_sorted = sorted(samples)
-    return samples_sorted[tail_size],samples_sorted[-tail_size-1]
+    return samples_sorted[tail_size], samples_sorted[-tail_size - 1]
+
 
 def highest_density_interval(samples, alpha=0.05):
     """The highest-density interval containing a (1-alpha) fraction of the posterior samples.
@@ -277,18 +290,21 @@ def highest_density_interval(samples, alpha=0.05):
     Returns: Left and right interval bounds (tuple)
     """
     samples_sorted = sorted(samples)
-    window_size = int(len(samples) - round(len(samples)*alpha))
+    window_size = int(len(samples) - round(len(samples) * alpha))
     smallest_window = (None, None)
-    smallest_window_length = float('inf')
+    smallest_window_length = float("inf")
     for i in range(len(samples_sorted) - window_size):
-        window = samples_sorted[i+window_size-1], samples_sorted[i]
-        window_length = samples_sorted[i+window_size-1] - samples_sorted[i]
+        window = samples_sorted[i + window_size - 1], samples_sorted[i]
+        window_length = samples_sorted[i + window_size - 1] - samples_sorted[i]
         if window_length < smallest_window_length:
             smallest_window_length = window_length
             smallest_window = window
     return smallest_window[1], smallest_window[0]
 
-def _bootstrap_replicate(X):
-    random_points = [0] + sorted(np.random.uniform(0, 1, len(X) - 1)) + [1]
-    gaps = [r - l for l, r in zip(random_points[:-1], random_points[1:])]
-    return gaps
+
+def _bootstrap_replicate(X, seed=None):
+    random_points = sorted(np.random.default_rng(seed).uniform(0, 1, len(X) - 1))
+    random_points.append(1)
+    random_points.insert(0, 0)
+    gaps = [right - left for left, right in zip(random_points[:-1], random_points[1:])]
+    return np.array(gaps)

--- a/bayesian_bootstrap/demos/demos.py
+++ b/bayesian_bootstrap/demos/demos.py
@@ -1,12 +1,19 @@
 from matplotlib import pyplot as plt
 import seaborn as sns
-from scipy.stats import norm
 from sklearn.linear_model import LinearRegression
 from sklearn.utils import resample
-from bayesian_bootstrap.bootstrap import mean, var, bayesian_bootstrap, bayesian_bootstrap_regression, \
-    BayesianBootstrapBagging, highest_density_interval, covar
+from bayesian_bootstrap.bootstrap import (
+    mean,
+    var,
+    bayesian_bootstrap,
+    bayesian_bootstrap_regression,
+    BayesianBootstrapBagging,
+    highest_density_interval,
+    covar,
+)
 from tqdm import tqdm
 import numpy as np
+
 
 def plot_mean_bootstrap():
     X = [-1, 0, 1]
@@ -16,6 +23,7 @@ def plot_mean_bootstrap():
     sns.distplot(classical_samples)
     plt.show()
 
+
 def plot_mean_resample_bootstrap():
     X = [-1, 0, 1]
     posterior_samples = bayesian_bootstrap(X, np.mean, 10000, 100)
@@ -23,6 +31,7 @@ def plot_mean_resample_bootstrap():
     classical_samples = [np.mean(resample(X)) for _ in range(10000)]
     sns.distplot(classical_samples)
     plt.show()
+
 
 def plot_median():
     X = np.random.uniform(-1, 1, 10)
@@ -32,6 +41,7 @@ def plot_median():
     sns.distplot(classical_samples)
     plt.show()
 
+
 def plot_var_bootstrap():
     X = np.random.uniform(-1, 1, 100)
     posterior_samples = var(X, 10000)
@@ -40,11 +50,13 @@ def plot_var_bootstrap():
     sns.distplot(classical_samples)
     plt.show()
 
+
 def plot_self_covar_bootstrap():
     X = np.random.uniform(-1, 1, 100)
     posterior_samples = covar(X, X, 10000)
     sns.distplot(posterior_samples)
     plt.show()
+
 
 def plot_covar_bootstrap():
     X = np.random.normal(0, 1, 100)
@@ -53,6 +65,7 @@ def plot_covar_bootstrap():
     sns.distplot(posterior_samples)
     plt.show()
 
+
 def plot_var_resample_bootstrap():
     X = np.random.uniform(-1, 1, 100)
     posterior_samples = bayesian_bootstrap(X, np.var, 10000, 500)
@@ -60,6 +73,7 @@ def plot_var_resample_bootstrap():
     classical_samples = [np.var(resample(X)) for _ in range(10000)]
     sns.distplot(classical_samples)
     plt.show()
+
 
 def plot_mean_method_comparison():
     X = np.random.exponential(scale=1, size=8)
@@ -71,20 +85,20 @@ def plot_mean_method_comparison():
     sns.distplot(posterior_samples_weighted)
     plt.show()
 
+
 def plot_regression_bootstrap():
     X = np.array([[0], [1], [2], [3]])
     y = np.array([0, 1, 2, 3]) + np.random.normal(0, 1, 4)
     classical_samples = [LinearRegression().fit(*resample(X, y)).coef_ for _ in tqdm(range(10000))]
-    posterior_samples =     bayesian_bootstrap_regression(X,
-                                                          y,
-                                                          lambda X, y: LinearRegression().fit(X, y).coef_,
-                                                          10000,
-                                                          1000)
+    posterior_samples = bayesian_bootstrap_regression(
+        X, y, lambda X, y: LinearRegression().fit(X, y).coef_, 10000, 1000
+    )
     plt.scatter(X.reshape(-1, 1), y)
     plt.show()
     sns.distplot(classical_samples)
     sns.distplot(posterior_samples)
     plt.show()
+
 
 def plot_regression_wrapper_bootstrap():
     X = np.array([[0], [1], [2], [3]])
@@ -95,9 +109,10 @@ def plot_regression_wrapper_bootstrap():
     y_predicted_interval = m.predict_central_interval(X, 0.05)
     plt.scatter(X.reshape(-1, 1), y)
     plt.plot(X.reshape(-1, 1), y_predicted)
-    plt.plot(X.reshape(-1, 1), y_predicted_interval[:,0])
-    plt.plot(X.reshape(-1, 1), y_predicted_interval[:,1])
+    plt.plot(X.reshape(-1, 1), y_predicted_interval[:, 0])
+    plt.plot(X.reshape(-1, 1), y_predicted_interval[:, 1])
     plt.show()
+
 
 def plot_mean_bootstrap_exponential_readme():
     X = np.random.exponential(7, 4)
@@ -106,18 +121,19 @@ def plot_mean_bootstrap_exponential_readme():
     l, r = highest_density_interval(posterior_samples)
     classical_l, classical_r = highest_density_interval(classical_samples)
     plt.subplot(2, 1, 1)
-    plt.title('Bayesian Bootstrap of mean')
-    sns.distplot(posterior_samples, label='Bayesian Bootstrap Samples')
-    plt.plot([l, r], [0, 0], linewidth=5.0, marker='o', label='95% HDI')
+    plt.title("Bayesian Bootstrap of mean")
+    sns.distplot(posterior_samples, label="Bayesian Bootstrap Samples")
+    plt.plot([l, r], [0, 0], linewidth=5.0, marker="o", label="95% HDI")
     plt.xlim(-1, 18)
     plt.legend()
     plt.subplot(2, 1, 2)
-    plt.title('Classical Bootstrap of mean')
-    sns.distplot(classical_samples, label='Classical Bootstrap Samples')
-    plt.plot([classical_l, classical_r], [0, 0], linewidth=5.0, marker='o', label='95% HDI')
+    plt.title("Classical Bootstrap of mean")
+    sns.distplot(classical_samples, label="Classical Bootstrap Samples")
+    plt.plot([classical_l, classical_r], [0, 0], linewidth=5.0, marker="o", label="95% HDI")
     plt.xlim(-1, 18)
     plt.legend()
-    plt.savefig('readme_exponential.png', bbox_inches='tight')
+    plt.savefig("readme_exponential.png", bbox_inches="tight")
+
 
 def plot_regression_slope_distribution_readme():
     X = np.random.normal(0, 1, 5).reshape(-1, 1)
@@ -128,13 +144,14 @@ def plot_regression_slope_distribution_readme():
     y_predicted = m.predict(X_plot.reshape(-1, 1))
     y_predicted_interval = m.predict_highest_density_interval(X_plot.reshape(-1, 1), 0.05)
     plt.scatter(X.reshape(1, -1), y)
-    plt.plot(X_plot, y_predicted, label='Mean')
-    plt.plot(X_plot, y_predicted_interval[:,0], label='95% HDI Lower bound')
-    plt.plot(X_plot, y_predicted_interval[:,1], label='95% HDI Upper bound')
+    plt.plot(X_plot, y_predicted, label="Mean")
+    plt.plot(X_plot, y_predicted_interval[:, 0], label="95% HDI Lower bound")
+    plt.plot(X_plot, y_predicted_interval[:, 1], label="95% HDI Upper bound")
     plt.legend()
-    plt.savefig('readme_regression.png', bbox_inches='tight')
+    plt.savefig("readme_regression.png", bbox_inches="tight")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     # plot_mean_bootstrap()
     # plot_mean_resample_bootstrap()
     # plot_median()

--- a/bayesian_bootstrap/demos/group_mean_secret_weapon.py
+++ b/bayesian_bootstrap/demos/group_mean_secret_weapon.py
@@ -1,23 +1,24 @@
 import numpy as np
 from bayesian_bootstrap.bootstrap import mean, highest_density_interval
-import seaborn as sns
 from matplotlib import pyplot as plt
+import seaborn as sns  # noqa: F401
+
 
 def plot_group_hdis(samples, labels, alpha, n_replications):
     for i, (s, l) in enumerate(zip(samples, labels)):
         posterior = mean(s, n_replications)
         l, r = highest_density_interval(posterior)
         plt.plot([i, i], [l, r])
-        plt.plot([i], [np.mean(posterior)], marker='o')
+        plt.plot([i], [np.mean(posterior)], marker="o")
     plt.xticks(range(len(labels)), labels)
 
-if __name__ == '__main__':
-    samples = [np.random.normal(0, 1, 100),
-               np.random.normal(0, 2, 100),
-               np.random.normal(1, 1, 100)]
-    labels = ['0,1', '0,2', '1,1']
-    plot_group_hdis(samples,
-                    labels,
-                    0.05,
-                    10000)
+
+if __name__ == "__main__":
+    samples = [
+        np.random.normal(0, 1, 100),
+        np.random.normal(0, 2, 100),
+        np.random.normal(1, 1, 100),
+    ]
+    labels = ["0,1", "0,2", "1,1"]
+    plot_group_hdis(samples, labels, 0.05, 10000)
     plt.show()

--- a/bayesian_bootstrap/demos/linear_regression.py
+++ b/bayesian_bootstrap/demos/linear_regression.py
@@ -4,7 +4,7 @@ import seaborn as sns
 from bayesian_bootstrap.bootstrap import linear_regression
 
 X = np.linspace(-5, 5, 50)
-y = 2*X + np.random.normal(0, 1, 50)
+y = 2 * X + np.random.normal(0, 1, 50)
 results = linear_regression(X.reshape(-1, 1), y, 1000)
-sns.distplot(results[:,0])
+sns.distplot(results[:, 0])
 plt.show()

--- a/bayesian_bootstrap/tests/test_bootstrap.py
+++ b/bayesian_bootstrap/tests/test_bootstrap.py
@@ -3,9 +3,17 @@ import numpy as np
 import scipy
 import random
 import bayesian_bootstrap.bootstrap as bb
-from bayesian_bootstrap.bootstrap import mean, var, bayesian_bootstrap, central_credible_interval, \
-    highest_density_interval, BayesianBootstrapBagging, covar
+from bayesian_bootstrap.bootstrap import (
+    mean,
+    var,
+    bayesian_bootstrap,
+    central_credible_interval,
+    highest_density_interval,
+    BayesianBootstrapBagging,
+    covar,
+)
 from sklearn.linear_model import LinearRegression
+
 
 class TestMoments(unittest.TestCase):
     def test_mean(self):
@@ -17,7 +25,7 @@ class TestMoments(unittest.TestCase):
     def test_variance(self):
         X = np.random.uniform(-1, 1, 500)
         posterior_samples = var(X, 10000)
-        self.assertAlmostEqual(np.mean(posterior_samples), 1/3., delta=0.05)
+        self.assertAlmostEqual(np.mean(posterior_samples), 1 / 3.0, delta=0.05)
 
     def test_self_covar(self):
         X = np.random.uniform(-1, 1, 500)
@@ -32,28 +40,28 @@ class TestMoments(unittest.TestCase):
 
     def test_mean_resample(self):
         X = [-1, 0, 1]
-        posterior_samples = bayesian_bootstrap(X, np.mean, 10000, 100,low_mem=True)
+        posterior_samples = bayesian_bootstrap(X, np.mean, 10000, 100, low_mem=True)
         self.assertAlmostEqual(np.mean(posterior_samples), 0, delta=0.01)
         self.assertAlmostEqual(len([s for s in posterior_samples if s < 0]), 5000, delta=1000)
-        posterior_samples = bayesian_bootstrap(X, np.mean, 10000, 100,low_mem=False)
+        posterior_samples = bayesian_bootstrap(X, np.mean, 10000, 100, low_mem=False)
         self.assertAlmostEqual(np.mean(posterior_samples), 0, delta=0.01)
         self.assertAlmostEqual(len([s for s in posterior_samples if s < 0]), 5000, delta=1000)
 
     def test_var_resample(self):
         X = np.random.uniform(-1, 1, 500)
         posterior_samples = bayesian_bootstrap(X, np.var, 10000, 5000, low_mem=True)
-        self.assertAlmostEqual(np.mean(posterior_samples), 1/3., delta=0.05)
+        self.assertAlmostEqual(np.mean(posterior_samples), 1 / 3.0, delta=0.05)
         X = np.random.uniform(-1, 1, 500)
         posterior_samples = bayesian_bootstrap(X, np.var, 10000, 5000, low_mem=False)
-        self.assertAlmostEqual(np.mean(posterior_samples), 1 / 3., delta=0.05)
+        self.assertAlmostEqual(np.mean(posterior_samples), 1 / 3.0, delta=0.05)
 
 
 class TestIntervals(unittest.TestCase):
     def test_central_credible_interval(self):
-        l,r = central_credible_interval(self._shuffle(list(range(10))), alpha=0.2)
+        l, r = central_credible_interval(self._shuffle(list(range(10))), alpha=0.2)
         self.assertEqual(l, 1)
         self.assertEqual(r, 8)
-        l,r = central_credible_interval(self._shuffle(list(range(10))), alpha=0.19)
+        l, r = central_credible_interval(self._shuffle(list(range(10))), alpha=0.19)
         self.assertEqual(l, 1)
         self.assertEqual(r, 8)
         l, r = central_credible_interval(self._shuffle(list(range(20))), alpha=0.1)
@@ -61,7 +69,7 @@ class TestIntervals(unittest.TestCase):
         self.assertEqual(r, 18)
 
     def test_hpdi(self):
-        l,r = highest_density_interval(self._shuffle([0, 10, 1] + [1.1]*7), alpha=0.2)
+        l, r = highest_density_interval(self._shuffle([0, 10, 1] + [1.1] * 7), alpha=0.2)
         self.assertEqual(l, 1)
         self.assertEqual(r, 1.1)
         l, r = highest_density_interval(self._shuffle([0, 10, 1.1, 1]), alpha=0.5)
@@ -72,6 +80,7 @@ class TestIntervals(unittest.TestCase):
         x = list(x)
         random.shuffle(x)
         return x
+
 
 class TestRegression(unittest.TestCase):
     def test_parameter_estimation_resampling_low_memory(self):
@@ -96,7 +105,6 @@ class TestRegression(unittest.TestCase):
         l, r = highest_density_interval(intercept_samples, alpha=0.05)
         self.assertLess(l, 0)
         self.assertGreater(r, 0)
-
 
     def test_parameter_estimation_resampling(self):
         X = np.random.uniform(0, 4, 1000)
@@ -177,19 +185,13 @@ def test_pearsonr():
     np.random.seed(1337)
     x = [0, 1, 3, 6]
     y = [1, 2, 5, 7]
-    assert np.isclose(
-        np.mean(bb.pearsonr(x, y, 10000)),
-        scipy.stats.pearsonr(x, y)[0], atol=0.001)
+    assert np.isclose(np.mean(bb.pearsonr(x, y, 10000)), scipy.stats.pearsonr(x, y)[0], atol=0.001)
 
     np.random.seed(1337)
     x = np.linspace(-10, 10, 10000)
     y = np.abs(x)
-    assert np.isclose(
-        scipy.stats.pearsonr(x, y)[0],
-        np.mean(bb.pearsonr(x, y, 1000)), atol=0.001)
+    assert np.isclose(scipy.stats.pearsonr(x, y)[0], np.mean(bb.pearsonr(x, y, 1000)), atol=0.001)
 
 
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
First of all, thanks _very_ much for this repo! I'd been hoping to move my bootstrapping to the Bayesian variety, and I appreciate this already existing.

Some people I've worked with were sticklers on (at least) two things WRT software: seedable PRNGs for reproducibility & formatting everything consistently. As such, in addition to adding a `seed` parameter to much of `bootstrap.py`, I took the liberty of running auto-formatting with `black -l 120` & appeasing `flake8` as best as I could.

All tests with `nosetests bayesian_bootstrap/tests` still pass.